### PR TITLE
Estructura inicial del módulo ProgramaEducativo

### DIFF
--- a/src/main/java/mx/edu/uteq/idgs12/microservicio_division/controller/ProgramaEducativoController.java
+++ b/src/main/java/mx/edu/uteq/idgs12/microservicio_division/controller/ProgramaEducativoController.java
@@ -1,0 +1,15 @@
+package mx.edu.uteq.idgs12.microservicio_division.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import mx.edu.uteq.idgs12.microservicio_division.service.ProgramaEducativoService;
+
+@RestController
+@RequestMapping("/api")
+public class ProgramaEducativoController {
+    @Autowired
+    private ProgramaEducativoService programaEducativoService;
+
+}

--- a/src/main/java/mx/edu/uteq/idgs12/microservicio_division/repository/ProgramaEducativoRepository.java
+++ b/src/main/java/mx/edu/uteq/idgs12/microservicio_division/repository/ProgramaEducativoRepository.java
@@ -1,0 +1,9 @@
+package mx.edu.uteq.idgs12.microservicio_division.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mx.edu.uteq.idgs12.microservicio_division.entity.ProgramaEducativo;
+
+public interface ProgramaEducativoRepository extends JpaRepository<ProgramaEducativo, Long> {
+
+}

--- a/src/main/java/mx/edu/uteq/idgs12/microservicio_division/service/ProgramaEducativoService.java
+++ b/src/main/java/mx/edu/uteq/idgs12/microservicio_division/service/ProgramaEducativoService.java
@@ -1,0 +1,17 @@
+package mx.edu.uteq.idgs12.microservicio_division.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import mx.edu.uteq.idgs12.microservicio_division.repository.DivisionRepository;
+import mx.edu.uteq.idgs12.microservicio_division.repository.ProgramaEducativoRepository;
+
+@Service
+public class ProgramaEducativoService {
+@Autowired
+    private ProgramaEducativoRepository programaEducativoRepository;
+
+    @Autowired
+    private DivisionRepository divisionRepository;
+
+}


### PR DESCRIPTION
Se agregaron los archivos base del módulo ProgramaEducativo con su estructura inicial en las capas de Controller, Service y Repository.
Esto servirá como punto de partida para que el resto del equipo pueda implementar la lógica y las funcionalidades correspondientes.